### PR TITLE
Fix S3 access for Lambda

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,6 +49,16 @@ Resources:
             Condition:
               StringEquals:
                 'AWS:SourceArn': !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/*"
+          - Sid: AllowAccountRead
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - s3:GetObject
+              - s3:ListBucket
+            Resource:
+              - !Sub "arn:aws:s3:::${StaticFilesBucket}"
+              - !Sub "arn:aws:s3:::${StaticFilesBucket}/*"
 
 Outputs:
   OACId:


### PR DESCRIPTION
## Summary
- add a bucket policy statement so the Lambda role can read files from the static bucket

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a647fc48c83318edbf03551875154