### PR TITLE
Fix staticfiles storage loading

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -105,10 +105,10 @@ AWS_S3_OBJECT_PARAMETERS = {
 # 静的ファイルの設定
 if AWS_S3_CUSTOM_DOMAIN:
     STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/'
-    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3StaticStorage'
+    STATICFILES_STORAGE = 'config.storage_backends.LocalManifestS3Storage'
     STORAGES = {
         "staticfiles": {
-            "BACKEND": "storages.backends.s3boto3.S3ManifestStaticStorage",
+            "BACKEND": "config.storage_backends.LocalManifestS3Storage",
         },
         "default": {
             "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",


### PR DESCRIPTION
## Summary
- use `LocalManifestS3Storage` when running on Lambda so manifest reads from the packaged directory

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685b3b235a7c83318892aa18ef771608