### PR TITLE
Fix CodeBuild Deps project BuildSpec property

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -215,9 +215,9 @@ Resources:
             Value: !Ref Env
       Source:
         Type: CODEPIPELINE
+        BuildSpec: buildspec-deps.yml
       Artifacts:
         Type: CODEPIPELINE
-      BuildSpec: buildspec-deps.yml
       Tags:
         - Key: env
           Value: !Ref Env


### PR DESCRIPTION
## Summary
- move `BuildSpec` property under `Source` for CodeBuildDepsProject

The stack deployment failed due to CloudFormation rejecting the `BuildSpec` property at the project level. Nesting it within `Source` resolves the `unsupported properties` error.

## Testing
- `sam validate` *(fails: command not found)*
- `aws --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0ce60ff88331bbb5e4f8041400fa