### PR TITLE
Fix pipeline deploy parameters and enable S3 logs

### DIFF
--- a/buildspec-deps.yml
+++ b/buildspec-deps.yml
@@ -22,11 +22,13 @@ phases:
           EXISTING_OAC_ID="";
         fi
       - |
-        cat > deps-parameters.json <<EOP
-        [
-          {"ParameterKey": "Env", "ParameterValue": "${ENV}"},
-          {"ParameterKey": "ExistingOACId", "ParameterValue": "${EXISTING_OAC_ID}"}
-        ]
+        cat > deps-parameters.json <<'EOP'
+        {
+          "Parameters": {
+            "Env": "${ENV}",
+            "ExistingOACId": "${EXISTING_OAC_ID}"
+          }
+        }
         EOP
 artifacts:
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -96,17 +96,13 @@ phases:
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成
       - |
-        cat > parameters.json << EOF
-        [
-          {
-            "ParameterKey": "Env",
-            "ParameterValue": "$ENV"
-          },
-          {
-            "ParameterKey": "ExistingARecord",
-            "ParameterValue": "$EXISTING_ARECORD"
+        cat > parameters.json <<'EOF'
+        {
+          "Parameters": {
+            "Env": "$ENV",
+            "ExistingARecord": "$EXISTING_ARECORD"
           }
-        ]
+        }
         EOF
       - echo "パラメータファイルを作成しました:"
       - cat parameters.json

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -193,6 +193,13 @@ Resources:
         Type: CODEPIPELINE
       Artifacts:
         Type: CODEPIPELINE
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Sub "/aws/codebuild/${CodePipelineName}-Build"
+          Status: ENABLED
+        S3Logs:
+          Status: ENABLED
+          Location: !Sub "${S3Bucket}/build-logs"
       Tags:
         - Key: env
           Value: !Ref Env
@@ -218,6 +225,13 @@ Resources:
         BuildSpec: buildspec-deps.yml
       Artifacts:
         Type: CODEPIPELINE
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Sub "/aws/codebuild/${CodePipelineName}-Deps"
+          Status: ENABLED
+        S3Logs:
+          Status: ENABLED
+          Location: !Sub "${S3Bucket}/build-logs"
       Tags:
         - Key: env
           Value: !Ref Env


### PR DESCRIPTION
## Summary
- fix CodeBuild parameter file format for CloudFormation TemplateConfiguration
- adjust app buildspec parameter format
- enable S3 logging for CodeBuild projects in pipeline

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685c1775f6cc8331b8543ea25a4565c5