### PR TITLE
Fix parameter expansion in deps buildspec

### DIFF
--- a/buildspec-deps.yml
+++ b/buildspec-deps.yml
@@ -22,7 +22,7 @@ phases:
           EXISTING_OAC_ID="";
         fi
       - |
-        cat > deps-parameters.json <<'EOP'
+        cat > deps-parameters.json <<EOP
         {
           "Parameters": {
             "Env": "${ENV}",


### PR DESCRIPTION
## Summary
- fix parameter expansion in `buildspec-deps.yml` so `Env` is expanded

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685c28c1515c8331a5d5a771fcf83e39