### PR TITLE
Fix CloudFront OAC detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ aws logs tail /aws/lambda/CobaemonServerlessPortfolioFunction --profile aws_port
 - **CI/CDパイプラインを使用する場合**: パイプラインを一度デプロイすれば、依存リソースとメインアプリケーションの両方が自動的に展開・更新されます
 - **手動デプロイの場合**: 依存関係→メインアプリケーションの順序でデプロイしてください
 - **既存リソースの自動検出**: CodePipeline がCloudFront Origin Access ControlとS3バケットを検出し、既存のものがあれば再利用します。パイプラインを使わない場合は `deploy-deps.ps1` を実行してください
+- CloudFront への操作はグローバルリージョン(us-east-1)で実行する必要があるため、
+  ビルドプロジェクトでは `AWS_DEFAULT_REGION=us-east-1` を設定しています
 - 本番環境では `Env=prod` パラメータを使用してください
 - カスタムドメインを使用する場合は、Route53でホストゾーンが設定されていることを確認してください
 

--- a/buildspec-deps.yml
+++ b/buildspec-deps.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     ENV: "prod"
+    AWS_DEFAULT_REGION: "us-east-1"
 
 phases:
   install:
@@ -15,7 +16,7 @@ phases:
     commands:
       - echo "Detecting existing CloudFront Origin Access Control..."
       - OAC_NAME="OAC-for-cobaemon-serverless-portfolio-${ENV}-static"
-      - EXISTING_OAC_ID=$(aws cloudfront list-origin-access-controls \
+      - EXISTING_OAC_ID=$(aws --region $AWS_DEFAULT_REGION cloudfront list-origin-access-controls \
           --query "OriginAccessControlList.Items[?Name=='${OAC_NAME}'].Id | [0]" \
           --output text || true)
       - if [ "$EXISTING_OAC_ID" = "None" ] || [ -z "$EXISTING_OAC_ID" ]; then


### PR DESCRIPTION
## Summary
- set AWS_DEFAULT_REGION for dependency build
- document the region requirement for CloudFront operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cc55aa6d48331b5bd28cab5e7888d