### PR TITLE
Fix OAC auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ aws logs tail /aws/lambda/CobaemonServerlessPortfolioFunction --profile aws_port
 - デプロイ前に必要なシークレットとパラメータがAWS Secrets ManagerとParameter Storeに設定されていることを確認してください
 - **CI/CDパイプラインを使用する場合**: パイプラインを一度デプロイすれば、依存リソースとメインアプリケーションの両方が自動的に展開・更新されます
 - **手動デプロイの場合**: 依存関係→メインアプリケーションの順序でデプロイしてください
-- **既存リソースの自動検出**: CodePipeline がCloudFront Origin Access ControlとS3バケットを検出し、既存のものがあれば再利用します。パイプラインを使わない場合は `deploy-deps.ps1` を実行してください
+- **既存リソースの自動検出**: CodePipeline がCloudFront Origin Access ControlとS3バケットを検出し、既存のものがあれば再利用します。見つからない場合はビルドステップが自動的にOACを作成し、そのIDをCloudFormationに渡します。パイプラインを使わない場合は `deploy-deps.ps1` を実行してください
 - CloudFront への操作はグローバルリージョン(us-east-1)で実行する必要があるため、
   ビルドプロジェクトでは `AWS_DEFAULT_REGION=us-east-1` を設定しています
 - 本番環境では `Env=prod` パラメータを使用してください

--- a/buildspec-deps.yml
+++ b/buildspec-deps.yml
@@ -20,7 +20,10 @@ phases:
           --query "OriginAccessControlList.Items[?Name=='${OAC_NAME}'].Id | [0]" \
           --output text || true)
       - if [ "$EXISTING_OAC_ID" = "None" ] || [ -z "$EXISTING_OAC_ID" ]; then
-          EXISTING_OAC_ID="";
+          echo "No existing OAC found. Creating new OAC ${OAC_NAME}...";
+          EXISTING_OAC_ID=$(aws --region $AWS_DEFAULT_REGION cloudfront create-origin-access-control \
+            --origin-access-control-config Name="${OAC_NAME}",OriginAccessControlOriginType=s3,SigningBehavior=always,SigningProtocol=sigv4 \
+            --query 'OriginAccessControl.Id' --output text);
         fi
       - echo "Detecting existing static files bucket..."
       - BUCKET_NAME="cobaemon-serverless-portfolio-${ENV}-static"


### PR DESCRIPTION
## Summary
- make CodeBuild create a new CloudFront OAC if one does not exist
- document this behaviour in the deployment notes

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`
- `black --check .` *(fails: would reformat 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_685cc97965ac8331bb2b8aac85f5a4c7