### PR TITLE
Fix build spec to use AWS CLI v2

### DIFF
--- a/buildspec-deps.yml
+++ b/buildspec-deps.yml
@@ -11,7 +11,8 @@ phases:
       python: 3.12
     commands:
       - pip install --upgrade pip
-      - pip install awscli
+      # Use pre-installed AWS CLI v2
+      - aws --version
   build:
     commands:
       - echo "Detecting existing CloudFront Origin Access Control..."


### PR DESCRIPTION
## Summary
- ensure CodeBuild uses pre-installed AWS CLI v2 instead of installing v1

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d16a5b7a08331811009f1330b8faf