### PR TITLE
Fix YAML here-doc delimiter

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -96,7 +96,7 @@ phases:
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成
       - |
-        cat > parameters.json <<'EOF'
+        cat > parameters.json <<EOF
         {
           "Parameters": {
             "Env": "$ENV",


### PR DESCRIPTION
## Summary
- ensure the heredoc delimiter in `buildspec.yml` doesn't use quotes

## Testing
- `pytest -q`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685dd2e0978483319a492e28e02d46eb