### PR TITLE
Fix CodeBuild YAML parse error

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -92,7 +92,7 @@ phases:
       - echo "SAMパッケージングを実行中..."
       # 環境変数を読み込み
       - source env_vars.txt
-      - echo "EXISTING_ARECORD: $EXISTING_ARECORD"
+      - 'echo "EXISTING_ARECORD: $EXISTING_ARECORD"'
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成
       - |


### PR DESCRIPTION
## Summary
- quote colon-containing command in `buildspec.yml`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685ddcab70308331915c6d72d32afa2c