### PR TITLE
Fix env_vars sourcing for CodeBuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -91,7 +91,7 @@ phases:
     commands:
       - echo "SAMパッケージングを実行中..."
       # 環境変数を読み込み
-      - source env_vars.txt
+      - . env_vars.txt
       - 'echo "EXISTING_ARECORD: $EXISTING_ARECORD"'
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成


### PR DESCRIPTION
## Summary
- fix shell sourcing command in `buildspec.yml`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e0c5de0e48331b1676bd6340aa3a1