### PR TITLE
Fix env vars sourcing in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,6 +36,8 @@ phases:
   pre_build:
     commands:
       - echo "SAMビルドの準備を開始..."
+      # env_vars.txt が存在しない場合に備えて初期化
+      - echo "EXISTING_ARECORD=false" > env_vars.txt
       
       # 既存のRoute53 Aレコードを検出
       - echo "既存のRoute53 Aレコードを検出中..."
@@ -91,7 +93,7 @@ phases:
     commands:
       - echo "SAMパッケージングを実行中..."
       # 環境変数を読み込み
-      - . env_vars.txt
+      - if [ -f env_vars.txt ]; then . env_vars.txt; fi
       - 'echo "EXISTING_ARECORD: $EXISTING_ARECORD"'
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成


### PR DESCRIPTION
## Summary
- initialize `env_vars.txt` to avoid missing file
- guard `. env_vars.txt` call with a file check

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685e13e57bf88331ad95aaaf9b89fa1e