### PR TITLE
Fix build script env var loading

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -93,7 +93,7 @@ phases:
     commands:
       - echo "SAMパッケージングを実行中..."
       # 環境変数を読み込み
-      - if [ -f env_vars.txt ]; then . env_vars.txt; fi
+      - if [ -f env_vars.txt ]; then . ./env_vars.txt; fi
       - 'echo "EXISTING_ARECORD: $EXISTING_ARECORD"'
       - sam package --output-template-file packaged.yaml --s3-bucket $S3Bucket
       # パラメータファイルを作成


### PR DESCRIPTION
## Summary
- fix path when sourcing `env_vars.txt` in buildspec

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e1a1d22688331a0676edee0ec048d