### PR TITLE
Fix missing bucket policy artifact

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -113,3 +113,4 @@ artifacts:
   files:
     - packaged.yaml
     - parameters.json
+    - bucketpolicy.yaml


### PR DESCRIPTION
## Summary
- include `bucketpolicy.yaml` in build artifacts so the CodePipeline deploy step can find it

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e8f8d7624833190b5eef49d683b81