### PR TITLE
Fix bucketpolicy deploy parameter mismatch

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -108,9 +108,21 @@ phases:
         EOF
       - echo "パラメータファイルを作成しました:"
       - cat parameters.json
+      # バケットポリシー用のパラメータファイルを作成
+      - |
+        cat > bucketpolicy-parameters.json <<EOF
+        {
+          "Parameters": {
+            "Env": "$ENV"
+          }
+        }
+        EOF
+      - echo "バケットポリシーパラメータファイルを作成しました:"
+      - cat bucketpolicy-parameters.json
 
 artifacts:
   files:
     - packaged.yaml
     - parameters.json
     - bucketpolicy.yaml
+    - bucketpolicy-parameters.json

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -163,7 +163,7 @@ Resources:
                 Capabilities: CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND,CAPABILITY_NAMED_IAM
                 StackName: !Sub "cobaemon-serverless-portfolio-bucketpolicy-${Env}"
                 TemplatePath: "BuildOutput::bucketpolicy.yaml"
-                TemplateConfiguration: BuildOutput::parameters.json
+                TemplateConfiguration: BuildOutput::bucketpolicy-parameters.json
                 OutputFileName: output-bucketpolicy.json
               RunOrder: 2
       Tags:


### PR DESCRIPTION
## Summary
- create bucketpolicy-parameters.json in buildspec
- use bucketpolicy-parameters.json when deploying bucketpolicy stack

## Testing
- `python manage.py test`
- `sam validate --region us-east-1`

------
https://chatgpt.com/codex/tasks/task_e_685eb5b3788c8331bb7c32c233151493