### PR TITLE
Auto-detect Route53 hosted zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ aws configure --profile aws_portfolio_profile
 - `/prod/portfolio/parameter/default_to_mail`
 - `/prod/portfolio/parameter/email_host`
 - `/prod/portfolio/parameter/email_port`
-- `/portfolio/parameter/hostzoneid`
+
+ホストゾーンIDはデプロイ時にRoute53から自動検出されるため、Parameter Storeでの管理は不要になりました。
 
 ## デプロイ手順
 
@@ -127,7 +128,14 @@ sam deploy --template-file dependencies.yaml --stack-name cobaemon-portfolio-dep
 #### 2. メインアプリケーションの手動デプロイ
 
 ```bash
-sam deploy --template-file template.yaml --stack-name cobaemon-serverless-portfolio-stack --capabilities CAPABILITY_NAMED_IAM --parameter-overrides Env=prod --profile aws_portfolio_profile
+HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
+  --dns-name portfolio.cobaemon.com \
+  --query 'HostedZones[0].Id' --output text | awk -F/ '{print $3}')
+sam deploy --template-file template.yaml \
+  --stack-name cobaemon-serverless-portfolio-stack \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides Env=prod HostedZoneId=$HOSTED_ZONE_ID \
+  --profile aws_portfolio_profile
 ```
 
 ### 設定ファイルを使用したデプロイ

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -43,7 +43,11 @@ phases:
       - echo "既存のRoute53 Aレコードを検出中..."
       - |
         DOMAIN_NAME="serverless.portfolio.cobaemon.com"
-        HOSTED_ZONE_ID=$(aws ssm get-parameter --name "/portfolio/parameter/hostzoneid" --query "Parameter.Value" --output text)
+        ROOT_DOMAIN=$(echo $DOMAIN_NAME | cut -d '.' -f2-)
+        HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
+          --dns-name "$ROOT_DOMAIN" \
+          --query 'HostedZones[0].Id' --output text | awk -F/ '{print $3}')
+        echo "HOSTED_ZONE_ID=$HOSTED_ZONE_ID" >> env_vars.txt
         
         # 既存のAレコードを検索
         EXISTING_RECORD=$(aws route53 list-resource-record-sets \
@@ -102,7 +106,8 @@ phases:
         {
           "Parameters": {
             "Env": "$ENV",
-            "ExistingARecord": "$EXISTING_ARECORD"
+            "ExistingARecord": "$EXISTING_ARECORD",
+            "HostedZoneId": "$HOSTED_ZONE_ID"
           }
         }
         EOF

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -6,7 +6,7 @@ s3_prefix = "cobaemon-serverless-portfolio-stack"
 region = "ap-northeast-1"
 capabilities = "CAPABILITY_NAMED_IAM"
 disable_rollback = true
-parameter_overrides = "Env=\"prod\" S3Bucket=\"cobaemon-serverless-portfolio-prod-artifacts\" CodePipelineName=\"cobaemon-serverless-portfolio-pipeline\" FullRepositoryId=\"cobaemon/ServerlessPortfolio\" BranchName=\"main\" StackName=\"cobaemon-serverless-portfolio-stack\" TemplatePath=\"packaged.yaml\" AllowedOrigin=\"/prod/portfolio/parameter/csrf_trusted_origins\" AllowedHosts=\"/prod/portfolio/parameter/allowed_hosts\" HostedZoneId=\"/portfolio/parameter/hostzoneid\" DomainName=\"serverless.portfolio.cobaemon.com\""
+parameter_overrides = "Env=\"prod\" S3Bucket=\"cobaemon-serverless-portfolio-prod-artifacts\" CodePipelineName=\"cobaemon-serverless-portfolio-pipeline\" FullRepositoryId=\"cobaemon/ServerlessPortfolio\" BranchName=\"main\" StackName=\"cobaemon-serverless-portfolio-stack\" TemplatePath=\"packaged.yaml\" AllowedOrigin=\"/prod/portfolio/parameter/csrf_trusted_origins\" AllowedHosts=\"/prod/portfolio/parameter/allowed_hosts\" DomainName=\"serverless.portfolio.cobaemon.com\""
 image_repositories = []
 profile = "aws_portfolio_profile"
 confirm_changeset = true

--- a/template.yaml
+++ b/template.yaml
@@ -22,8 +22,7 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /prod/portfolio/parameter/allowed_hosts
   HostedZoneId:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /portfolio/parameter/hostzoneid
+    Type: String
     Description: "Route53 Hosted Zone ID for custom domain"
   DomainName:
     Type: String


### PR DESCRIPTION
## Summary
- auto-detect hosted zone ID in buildspec.yml
- pass HostedZoneId to CloudFormation
- drop SSM usage for hosted zone in template
- update docs and samconfig for auto detection

## Testing
- `pytest -q`
- `sam validate -t template.yaml --region ap-northeast-1`
- `sam validate -t pipeline.yaml --region ap-northeast-1`


------
https://chatgpt.com/codex/tasks/task_e_685ed5c383cc8331aa27e587654bb735