### PR TITLE
Fix hosted zone search

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ sam deploy --template-file dependencies.yaml --stack-name cobaemon-portfolio-dep
 
 ```bash
 HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
-  --dns-name portfolio.cobaemon.com \
+  --dns-name cobaemon.com \
   --query 'HostedZones[0].Id' --output text | awk -F/ '{print $3}')
+if [ -z "$HOSTED_ZONE_ID" ] || [ "$HOSTED_ZONE_ID" = "None" ]; then
+  echo "Hosted zone not found for cobaemon.com" >&2
+  exit 1
+fi
 sam deploy --template-file template.yaml \
   --stack-name cobaemon-serverless-portfolio-stack \
   --capabilities CAPABILITY_NAMED_IAM \

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -43,10 +43,16 @@ phases:
       - echo "既存のRoute53 Aレコードを検出中..."
       - |
         DOMAIN_NAME="serverless.portfolio.cobaemon.com"
-        ROOT_DOMAIN=$(echo $DOMAIN_NAME | cut -d '.' -f2-)
+        ROOT_DOMAIN=$(echo $DOMAIN_NAME | awk -F'.' '{print $(NF-1)"."$NF}')
         HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name \
           --dns-name "$ROOT_DOMAIN" \
           --query 'HostedZones[0].Id' --output text | awk -F/ '{print $3}')
+
+        if [ -z "$HOSTED_ZONE_ID" ] || [ "$HOSTED_ZONE_ID" = "None" ]; then
+          echo "Hosted zone not found for $ROOT_DOMAIN" >&2
+          exit 1
+        fi
+
         echo "HOSTED_ZONE_ID=$HOSTED_ZONE_ID" >> env_vars.txt
         
         # 既存のAレコードを検索


### PR DESCRIPTION
## Summary
- refine the domain parsing logic in the build spec so it looks up the correct hosted zone
- adjust manual deployment instructions to query `cobaemon.com` instead of a nonexistent subdomain

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685f5e8f27e4833190238b5ea654db84