### PR TITLE
Fix A record deletion on redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ aws s3 sync staticfiles/ s3://cobaemon-serverless-portfolio-prod-static/ --delet
    - メールサーバーの設定を確認
    - ネットワーク設定を確認
 
+4. **ドメインが解決できない**
+   - `serverless.portfolio.cobaemon.com` が NXDOMAIN となる場合、Route53 に正しい A レコードが作成されているか確認
+   - ホストゾーン自体が存在しない場合は、`cobaemon.com` 用のホストゾーンを作成し、スタックを再デプロイ
+   - 再デプロイ後に A レコードが消える場合は、CodeBuild の環境変数 `EXISTING_ARECORD` を `false` に固定する
+   - DNS 反映まで最大 48 時間かかることがあるため、変更後しばらく待ってから再度アクセスする
+
 ### ログの確認
 
 ```bash

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -54,19 +54,30 @@ phases:
         fi
 
         echo "HOSTED_ZONE_ID=$HOSTED_ZONE_ID" >> env_vars.txt
-        
-        # 既存のAレコードを検索
-        EXISTING_RECORD=$(aws route53 list-resource-record-sets \
-          --hosted-zone-id $HOSTED_ZONE_ID \
-          --query "ResourceRecordSets[?Name=='$DOMAIN_NAME.' && Type=='A']" \
-          --output text)
-        
-        if [ -n "$EXISTING_RECORD" ]; then
-          echo "既存のAレコードを検出しました: $DOMAIN_NAME"
-          echo "EXISTING_ARECORD=true" >> env_vars.txt
-        else
-          echo "既存のAレコードが見つかりませんでした。新規作成します。"
+
+        STACK_NAME="cobaemon-serverless-portfolio-stack"
+        CFN_RECORD=$(aws cloudformation describe-stack-resource \
+          --stack-name $STACK_NAME \
+          --logical-resource-id ApiGatewayRecordSet \
+          --query 'StackResourceDetail.PhysicalResourceId' \
+          --output text 2>/dev/null || true)
+
+        if [ "$CFN_RECORD" != "None" ] && [ -n "$CFN_RECORD" ]; then
+          echo "Stack already manages A record: $CFN_RECORD"
           echo "EXISTING_ARECORD=false" >> env_vars.txt
+        else
+          EXISTING_RECORD=$(aws route53 list-resource-record-sets \
+            --hosted-zone-id $HOSTED_ZONE_ID \
+            --query "ResourceRecordSets[?Name=='$DOMAIN_NAME.' && Type=='A']" \
+            --output text)
+
+          if [ -n "$EXISTING_RECORD" ]; then
+            echo "A record exists outside CloudFormation: $DOMAIN_NAME"
+            echo "EXISTING_ARECORD=true" >> env_vars.txt
+          else
+            echo "No existing A record found. It will be created by the stack."
+            echo "EXISTING_ARECORD=false" >> env_vars.txt
+          fi
         fi
       
       # 多言語対応のための翻訳ファイル処理


### PR DESCRIPTION
## Summary
- avoid deleting Route53 A record when the stack updates
- document fixing `EXISTING_ARECORD`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685fc8b7f6e083318a69977ebf9ab85b