### PR TITLE
Fix CSP config and verify static paths

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 import os
 from pathlib import Path
+from csp import constants as csp_constants
 
 from django.contrib import messages
 from django.urls import reverse_lazy
@@ -180,45 +181,48 @@ STORAGES = {
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CSP_DEFAULT_SRC = ("'self'", 'https:')
-CSP_SCRIPT_SRC = (
-    "'self'",
-    'https://use.fontawesome.com',
-    'https://cdn.jsdelivr.net',
-    'https://cdn.startbootstrap.com',
-)
-CSP_SCRIPT_SRC_ELEM = (
-    "'self'",
-    'https://use.fontawesome.com',
-    'https://cdn.jsdelivr.net',
-    'https://cdn.startbootstrap.com',
-)
-CSP_STYLE_SRC = (
-    "'self'",
-    'https://fonts.googleapis.com',
-    'https://use.fontawesome.com',
-    'https://cdn.jsdelivr.net',
-    'https://cdn.startbootstrap.com',
-)
-CSP_STYLE_SRC_ELEM = (
-    "'self'",
-    'https://fonts.googleapis.com',
-    'https://use.fontawesome.com',
-    'https://cdn.jsdelivr.net',
-    'https://cdn.startbootstrap.com',
-)
-CSP_FONT_SRC = ("'self'", 'https://fonts.gstatic.com')
-CSP_IMG_SRC = ("'self'", 'data:')
-CSP_OBJECT_SRC = ("'none'")
-CSP_BASE_URI = ("'self'")
-CSP_FRAME_SRC = ("'none'")
-CSP_FRAME_ANCESTORS = ("'none'")
-CSP_REPORT_URI = ('/csp-report-endpoint',)
-
-# nonceを有効化
-CSP_INCLUDE_NONCE_IN = ['script-src', 'script-src-elem', 'style-src', 'style-src-elem']
-CSP_STYLE_SRC_NONCE = True
-CSP_SCRIPT_SRC_NONCE = True
+CONTENT_SECURITY_POLICY = {
+    'DIRECTIVES': {
+        'default-src': ["'self'", 'https:'],
+        'script-src': [
+            "'self'",
+            'https://use.fontawesome.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdn.startbootstrap.com',
+            csp_constants.NONCE,
+        ],
+        'script-src-elem': [
+            "'self'",
+            'https://use.fontawesome.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdn.startbootstrap.com',
+            csp_constants.NONCE,
+        ],
+        'style-src': [
+            "'self'",
+            'https://fonts.googleapis.com',
+            'https://use.fontawesome.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdn.startbootstrap.com',
+            csp_constants.NONCE,
+        ],
+        'style-src-elem': [
+            "'self'",
+            'https://fonts.googleapis.com',
+            'https://use.fontawesome.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdn.startbootstrap.com',
+            csp_constants.NONCE,
+        ],
+        'font-src': ["'self'", 'https://fonts.gstatic.com'],
+        'img-src': ["'self'", 'data:'],
+        'object-src': ["'none'"],
+        'base-uri': ["'self'"],
+        'frame-src': ["'none'"],
+        'frame-ancestors': ["'none'"],
+        'report-uri': ['/csp-report-endpoint'],
+    }
+}
 
 # Django Allauth設定
 # SITE_ID = 1

--- a/scripts/check_static_manifest.py
+++ b/scripts/check_static_manifest.py
@@ -1,0 +1,34 @@
+import json
+import sys
+from pathlib import Path
+
+# Load static paths from templates
+from django.conf import settings
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+manifest_path = BASE_DIR / 'staticfiles' / 'staticfiles.json'
+templates_dir = BASE_DIR / 'templates'
+
+# Load manifest
+with open(manifest_path, 'r') as f:
+    manifest = json.load(f)['paths']
+
+missing = []
+
+# Extract static paths from templates
+import re
+pattern = re.compile(r"\{\% static '(.*?)' \%\}")
+
+for template_file in templates_dir.rglob('*.html'):
+    with open(template_file, 'r') as f:
+        for match in pattern.findall(f.read()):
+            if match not in manifest:
+                missing.append((template_file, match))
+
+if missing:
+    print('Missing manifest entries:')
+    for tpl, path in missing:
+        print(f"{tpl}: {path}")
+    sys.exit(1)
+print('All static file references are valid.')

--- a/templates/portfolio_base.html
+++ b/templates/portfolio_base.html
@@ -481,7 +481,7 @@
                                     <picture>
                                         <source srcset="{% static 'assets/img/portfolio/vocabulary-notebook.avif' %}" type="image/avif">
                                         <source srcset="{% static 'assets/img/portfolio/vocabulary-notebook.webp' %}" type="image/webp">
-                                        <img class="img-fluid rounded mb-5" src="{% static 'assets/img/vocabulary-notebook.png' %}" alt="..." loading="lazy">
+                                        <img class="img-fluid rounded mb-5" src="{% static 'assets/img/portfolio/vocabulary-notebook.png' %}" alt="..." loading="lazy">
                                     </picture>
                                     <!-- Portfolio Modal - Text-->
                                     <h5>Summary</h5>


### PR DESCRIPTION
## Summary
- migrate old CSP_* settings to new CONTENT_SECURITY_POLICY format
- keep vocabulary notebook image under portfolio directory
- include script for checking static manifest consistency

## Testing
- `python manage.py test --settings=config.settings.dev`
- `python scripts/check_static_manifest.py`


------
https://chatgpt.com/codex/tasks/task_e_685fdf71b2248331a719817770da6935