### PR TITLE
Enable TLS email settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ sam deploy --template-file dependencies.yaml `
 - `DEFAULT_TO_EMAIL`: デフォルト宛先メールアドレス
 - `EMAIL_HOST`: メールサーバーホスト
 - `EMAIL_PORT`: メールサーバーポート
+- `EMAIL_USE_TLS`: TLSを使用する場合は`True`
+- `EMAIL_USE_SSL`: SSLを使用する場合は`True`
 
 ## 開発
 
@@ -242,6 +244,17 @@ python manage.py makemessages -l en
 # 翻訳ファイルのコンパイル
 python manage.py compilemessages
 ```
+
+ローカルでSMTP送信をテストする場合は、`.env` に以下の環境変数を設定します。
+
+- `EMAIL_HOST`
+- `EMAIL_PORT`
+- `EMAIL_HOST_USER`
+- `EMAIL_HOST_PASSWORD`
+- `DEFAULT_FROM_EMAIL`
+- `DEFAULT_TO_EMAIL`
+
+設定がない場合は `django.core.mail.backends.console.EmailBackend` が使用されます。
 
 ### テスト
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,6 +23,8 @@ env:
     DEFAULT_TO_EMAIL: "/prod/portfolio/parameter/default_to_mail"
     EMAIL_HOST: "/prod/portfolio/parameter/email_host"
     EMAIL_PORT: "/prod/portfolio/parameter/email_port"
+    EMAIL_USE_TLS: "/prod/portfolio/parameter/email_use_tls"
+    EMAIL_USE_SSL: "/prod/portfolio/parameter/email_use_ssl"
 
 phases:
   install:

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -20,8 +20,6 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-default-secret-key")
 
 # ALLOWED_HOSTS は、.envや環境変数に値があればそれを使用、なければデフォルトで localhost,127.0.0.1
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1").split(',')
-
-print(f'\n\n{ALLOWED_HOSTS}\n\n')
 if "127.0.0.1" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("127.0.0.1")
 # SAM Local でのリクエストヘッダーに "127.0.0.1:3000" が含まれるため、それも追加
@@ -34,3 +32,19 @@ DATABASES = {
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
+
+# Email configuration (optional)
+EMAIL_HOST = os.environ.get("EMAIL_HOST")
+EMAIL_PORT = os.environ.get("EMAIL_PORT")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "webmaster@localhost")
+DEFAULT_TO_EMAIL = os.environ.get("DEFAULT_TO_EMAIL", "")
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False") == "True"
+EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False") == "True"
+
+if EMAIL_HOST:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -81,6 +81,10 @@ EMAIL_PORT = os.environ.get("EMAIL_PORT")
 if not EMAIL_PORT:
     raise ImproperlyConfigured("Set the EMAIL_PORT environment variable")
 
+# Optional TLS/SSL settings
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False") == "True"
+EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False") == "True"
+
 # セキュリティ強化のための設定
 SECURE_SSL_REDIRECT = True
 SESSION_COOKIE_SECURE = True

--- a/template.yaml
+++ b/template.yaml
@@ -70,6 +70,8 @@ Resources:
           DEFAULT_TO_EMAIL: "{{resolve:ssm:/prod/portfolio/parameter/default_to_mail}}"
           EMAIL_HOST: "{{resolve:ssm:/prod/portfolio/parameter/email_host}}"
           EMAIL_PORT: "{{resolve:ssm:/prod/portfolio/parameter/email_port}}"
+          EMAIL_USE_TLS: "{{resolve:ssm:/prod/portfolio/parameter/email_use_tls}}"
+          EMAIL_USE_SSL: "{{resolve:ssm:/prod/portfolio/parameter/email_use_ssl}}"
           STATIC_URL: !Sub "https://${CloudFrontDistribution.DomainName}/"
           CLOUDFRONT_DOMAIN_NAME: !GetAtt CloudFrontDistribution.DomainName
           ENV: !Ref Env


### PR DESCRIPTION
## Summary
- add TLS/SSL configuration for production email
- allow optional SMTP settings in development
- document email environment variables

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860772430908331ac97993ad46476b2