### PR TITLE
Improve logging for failed email sends

### DIFF
--- a/portfolio/forms.py
+++ b/portfolio/forms.py
@@ -1,6 +1,9 @@
 from django import forms
 from django.conf import settings
 from django.core.mail import EmailMessage
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ContactForm(forms.Form):
@@ -75,6 +78,13 @@ class ContactForm(forms.Form):
             subject,
             body,
             from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[settings.DEFAULT_TO_EMAIL]
+            to=[settings.DEFAULT_TO_EMAIL],
         )
-        email.send()
+
+        try:
+            email.send()
+            logger.info("Contact email sent to %s", settings.DEFAULT_TO_EMAIL)
+            return True
+        except Exception as exc:
+            logger.error("Failed to send contact email: %s", exc, exc_info=True)
+            return False

--- a/portfolio/views.py
+++ b/portfolio/views.py
@@ -17,8 +17,9 @@ class Top(FormView):
         フォームが有効な場合の処理
         お問い合わせ内容をメール送信し、成功メッセージを返す
         """
-        form.send_email()
-        return HttpResponse("Form submission successful")
+        if form.send_email():
+            return HttpResponse("Form submission successful")
+        return HttpResponse("Email sending failed", status=500)
         
     def get_context_data(self, **kwargs):
         """


### PR DESCRIPTION
## Summary
- add logging for contact form emails
- handle send failures gracefully

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686168af77d0833188e9ec683a19a1ac