### PR TITLE
Improve email debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,13 @@ python manage.py compilemessages
 - `EMAIL_HOST_PASSWORD`
 - `DEFAULT_FROM_EMAIL`
 - `DEFAULT_TO_EMAIL`
+- `EMAIL_USE_TLS` または `EMAIL_USE_SSL`
+
+Gmail 等の外部 SMTP サーバーを利用する場合は、`EMAIL_PORT=587` と
+`EMAIL_USE_TLS=True` を指定するのが一般的です。
 
 設定がない場合は `django.core.mail.backends.console.EmailBackend` が使用されます。
+メールの内容はCloudWatch Logsに出力されますが、実際の送信は行われません。
 
 ### テスト
 

--- a/portfolio/forms.py
+++ b/portfolio/forms.py
@@ -81,6 +81,15 @@ class ContactForm(forms.Form):
             to=[settings.DEFAULT_TO_EMAIL],
         )
 
+        logger.info("Using email backend %s", settings.EMAIL_BACKEND)
+        logger.info(
+            "Using SMTP server %s:%s TLS=%s SSL=%s",
+            settings.EMAIL_HOST,
+            settings.EMAIL_PORT,
+            settings.EMAIL_USE_TLS,
+            settings.EMAIL_USE_SSL,
+        )
+
         try:
             email.send()
             logger.info("Contact email sent to %s", settings.DEFAULT_TO_EMAIL)

--- a/portfolio/views.py
+++ b/portfolio/views.py
@@ -1,7 +1,10 @@
 from django.http import HttpResponse
 from django.views.generic import FormView
+import logging
 
 from .forms import ContactForm
+
+logger = logging.getLogger(__name__)
 
 
 class Top(FormView):
@@ -20,6 +23,14 @@ class Top(FormView):
         if form.send_email():
             return HttpResponse("Form submission successful")
         return HttpResponse("Email sending failed", status=500)
+
+    def form_invalid(self, form):
+        """
+        フォームが無効な場合の処理
+        バリデーションエラーをログに出力
+        """
+        logger.warning("Invalid contact form submission: %s", form.errors)
+        return super().form_invalid(form)
         
     def get_context_data(self, **kwargs):
         """


### PR DESCRIPTION
## Summary
- log the email backend and log invalid form submissions
- clarify that console backend only logs output to CloudWatch

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings.dev python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686272471b288331828dd5d640f53422