### PR TITLE
Fix contact form for AWS API Gateway

### DIFF
--- a/portfolio/static/js/scripts.js
+++ b/portfolio/static/js/scripts.js
@@ -93,12 +93,15 @@ window.addEventListener('DOMContentLoaded', event => {
         event.preventDefault();
 
         const formData = new FormData(contactForm);
+        // API Gatewayでは multipart/form-data の解析が正しく行われないため、
+        // URL エンコード形式で送信する
         const response = await fetch(contactForm.action, {
             method: 'POST',
-            body: formData,
+            body: new URLSearchParams(formData),
             headers: {
                 'X-Requested-With': 'XMLHttpRequest',  // DjangoがAjaxリクエストとして認識するために必要です。
                 'X-CSRFToken': contactForm.querySelector('[name="csrfmiddlewaretoken"]').value,
+                'Content-Type': 'application/x-www-form-urlencoded',
             },
         });
 


### PR DESCRIPTION
## Summary
- avoid multipart/form-data in AJAX submission

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `DJANGO_SETTINGS_MODULE=config.settings.dev python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686287f3e4fc833199ab9347cfb14dee