### PR TITLE
Add check for mutually exclusive TLS/SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ sam deploy --template-file dependencies.yaml `
 - `EMAIL_PORT`: メールサーバーポート
 - `EMAIL_USE_TLS`: TLSを使用する場合は`True`
 - `EMAIL_USE_SSL`: SSLを使用する場合は`True`
+  - **注意:** `EMAIL_USE_TLS` と `EMAIL_USE_SSL` は同時に `True` に設定できません。
+    どちらか片方のみを有効にしてください。
 
 ### 環境変数
 - `LOG_LEVEL`: アプリケーションのログレベル (例: INFO)。Parameter Store `/prod/portfolio/parameter/log_level` で管理
@@ -258,6 +260,7 @@ python manage.py compilemessages
 - `DEFAULT_FROM_EMAIL`
 - `DEFAULT_TO_EMAIL`
 - `EMAIL_USE_TLS` または `EMAIL_USE_SSL`
+  - 両方を `True` にするとエラーになります。必ずどちらか一方のみ設定してください。
 
 Gmail 等の外部 SMTP サーバーを利用する場合は、`EMAIL_PORT=587` と
 `EMAIL_USE_TLS=True` を指定するのが一般的です。

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 from .base import *
 
@@ -42,6 +43,11 @@ DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "webmaster@localhost")
 DEFAULT_TO_EMAIL = os.environ.get("DEFAULT_TO_EMAIL", "")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False") == "True"
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False") == "True"
+
+if EMAIL_USE_TLS and EMAIL_USE_SSL:
+    raise ImproperlyConfigured(
+        "EMAIL_USE_TLS and EMAIL_USE_SSL are mutually exclusive. Set only one to True."
+    )
 
 if EMAIL_HOST:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -84,6 +84,10 @@ if not EMAIL_PORT:
 # Optional TLS/SSL settings
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False") == "True"
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False") == "True"
+if EMAIL_USE_TLS and EMAIL_USE_SSL:
+    raise ImproperlyConfigured(
+        "EMAIL_USE_TLS and EMAIL_USE_SSL are mutually exclusive. Set only one to True."
+    )
 
 # セキュリティ強化のための設定
 SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
## Summary
- validate TLS and SSL flags to avoid misconfiguration
- document that TLS and SSL cannot both be enabled

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6862989eb65c8331973160da63bdaee1