### PR TITLE
Set Lambda to arm64 with 512MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ aws logs tail /aws/lambda/CobaemonServerlessPortfolioFunction --profile aws_port
 ## パフォーマンス最適化
 
 - CloudFrontによる静的ファイルのキャッシュ
-- Lambda関数のメモリとタイムアウト設定の最適化
+- Lambda関数のメモリ(512MB)とタイムアウト設定の最適化、arm64アーキテクチャの採用
 - 画像の最適化（Pillow AVIFプラグイン使用）
 - データベース接続の最適化
 

--- a/template.yaml
+++ b/template.yaml
@@ -5,6 +5,9 @@ Description: CodePipeline for Serverless Portfolio using SAM
 Globals:
   Function:
     Timeout: 30
+    MemorySize: 512
+    Architectures:
+      - arm64
 
 Parameters:
   Env:


### PR DESCRIPTION
## Summary
- allocate 512MB memory and use arm64 for Lambdas
- document the change in performance optimization section

## Testing
- `pip install -r requirements.txt`
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6862b52390f08331a64da029739bae1c