### PR TITLE
Fix build failure by switching to x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ aws logs tail /aws/lambda/CobaemonServerlessPortfolioFunction --profile aws_port
 ## パフォーマンス最適化
 
 - CloudFrontによる静的ファイルのキャッシュ
-- Lambda関数のメモリ(512MB)とタイムアウト設定の最適化、arm64アーキテクチャの採用
+- Lambda関数のメモリ(512MB)とタイムアウト設定の最適化
 - 画像の最適化（Pillow AVIFプラグイン使用）
 - データベース接続の最適化
 

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Globals:
     Timeout: 30
     MemorySize: 512
     Architectures:
-      - arm64
+      - x86_64
 
 Parameters:
   Env:


### PR DESCRIPTION
## Summary
- build was failing when building for arm64
- use x86_64 Lambda architecture instead

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863b7e892ec8331a76c8f7706bf161f