### PR TITLE
Fix buildspec YAML block indentation

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -112,10 +112,10 @@ phases:
       # CSS minification
       - |
         python - <<'EOF'
-import pathlib, csscompressor
-src = pathlib.Path('portfolio/static/css/styles.css').read_text()
-pathlib.Path('portfolio/static/css/styles.min.css').write_text(csscompressor.compress(src))
-EOF
+        import pathlib, csscompressor
+        src = pathlib.Path('portfolio/static/css/styles.css').read_text()
+        pathlib.Path('portfolio/static/css/styles.min.css').write_text(csscompressor.compress(src))
+        EOF
 
       # 静的ファイルの収集とS3への同期
       - python manage.py collectstatic --noinput


### PR DESCRIPTION
## Summary
- fix indentation in the CSS minification section of `buildspec.yml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import yaml
with open('buildspec.yml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68646d9a2bc083318be2661ca07aa643